### PR TITLE
Adding spec coverage and fix string bug

### DIFF
--- a/lib/db/snapshot.rb
+++ b/lib/db/snapshot.rb
@@ -8,7 +8,7 @@ module Db
 
     def self.create(snapshot_name = '')
       date_time = Time.now.strftime("%Y%m%d_%H%M")
-      if snapshot_name.present?
+      if !snapshot_name.empty?
         database_name = snapshot_name
       else
         database_name = Mongoid.default_session.options[:database]

--- a/spec/db/snapshot_spec.rb
+++ b/spec/db/snapshot_spec.rb
@@ -5,7 +5,34 @@ describe Db::Snapshot do
     expect(Db::Snapshot::VERSION).not_to be nil
   end
 
-  it 'does something useful' do
-    # pending
+  describe '.list' do
+    it 'returns the correct system command' do
+      expect_any_instance_of(Kernel)
+        .to receive(:system)
+        .with('ls -la -tr dump/')
+
+        Db::Snapshot.list
+    end
+  end
+
+  describe '.create' do
+    context 'when snapshot_name is not an empty string' do
+      it 'returns the correct system command' do
+        expect_any_instance_of(Kernel)
+          .to receive(:system)
+
+        Db::Snapshot.create("HELLO")
+      end
+    end
+  end
+
+  describe '.travel_to' do
+    it 'calls the restore method' do
+      expect(described_class)
+        .to receive(:restore)
+        .with('20160612_2115')
+
+      Db::Snapshot.travel_to('20160612_2115')
+    end
   end
 end


### PR DESCRIPTION
### In this PR
Link to original Issue [here](https://github.com/mcka1n/db-snapshot/issues/1)

- [x] Fix bug in the `create` method if no `snapshot_name` is passed in as an argument.
Calling `present?` on an empty string returns runtime error:
```
# Failure/Error: if snapshot_name.present?
#
#     NoMethodError:
#       undefined method `present?' for "":String
#       Did you mean?  prepend
```

- [x] Added some specs to expose the bug and additional test coverage for other methods.


I have a question! I would like to write some more tests but it looks like when the `Mongoid` class is called in the test suite or in the dev console we are getting an `uninitialized constant Db::Snapshot::Mongoid` error, any thoughts on resolving this either locally or otherwise?

Thanks so much! and let me know if you have any feedback or ideas 👋 